### PR TITLE
fix(Npm): build problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint:all": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "sb build",
-    "test": "echo \"No tests\" && exit 0"
+    "test": "echo \"No tests\" && exit 0",
+    "typecheck": "npm run build -- --noEmit",
+    "prepublishOnly": "npm run typecheck && npm run build"
   },
   "dependencies": {
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Summary by Sourcery

Add typecheck and prepublishOnly npm scripts to enforce type checking and automatic build before publishing

Enhancements:
- Add "typecheck" script to run build with --noEmit for type checking
- Add "prepublishOnly" script to run typecheck and build on npm publish