### PR TITLE
feat(Events): passing visual configuration to renderer

### DIFF
--- a/src/CanvasApi.ts
+++ b/src/CanvasApi.ts
@@ -9,6 +9,7 @@ import { TimelineAxis } from "./types/axis";
 import { TimelineEvent } from "./types/events";
 import { Markers } from "./components/Markers";
 import { TimelineMarker } from "./types/markers";
+import { ViewConfiguration } from "./types";
 
 export class CanvasApi {
   public readonly canvas: HTMLCanvasElement;
@@ -54,7 +55,7 @@ export class CanvasApi {
     this.ctx.restore();
   }
 
-  public getVisualConfiguration() {
+  public getVisualConfiguration(): ViewConfiguration {
     return this.timeline.viewConfiguration;
   }
 

--- a/src/CanvasApi.ts
+++ b/src/CanvasApi.ts
@@ -9,7 +9,6 @@ import { TimelineAxis } from "./types/axis";
 import { TimelineEvent } from "./types/events";
 import { Markers } from "./components/Markers";
 import { TimelineMarker } from "./types/markers";
-import { ViewConfiguration } from "./types";
 
 export class CanvasApi {
   public readonly canvas: HTMLCanvasElement;
@@ -55,7 +54,7 @@ export class CanvasApi {
     this.ctx.restore();
   }
 
-  public getVisualConfiguration(): ViewConfiguration {
+  public getViewConfiguration() {
     return this.timeline.viewConfiguration;
   }
 

--- a/src/components/Axes.ts
+++ b/src/components/Axes.ts
@@ -59,7 +59,7 @@ export class Axes<Axis extends TimelineAxis = TimelineAxis>
       throw new Error("Invalid axis configuration");
     }
 
-    const { axes } = this.api.getVisualConfiguration();
+    const { axes } = this.api.getViewConfiguration();
     const index = clamp(trackIndex, 0, axis.tracksCount - 1);
     return axis.top + axes.trackHeight * index + axes.trackHeight / 2;
   }
@@ -68,7 +68,7 @@ export class Axes<Axis extends TimelineAxis = TimelineAxis>
    * Renders all axes to the canvas
    */
   public render() {
-    const { axes } = this.api.getVisualConfiguration();
+    const { axes } = this.api.getViewConfiguration();
     const { ctx } = this.api;
 
     if (this.strokeMode === StrokeMode.DASHED) {

--- a/src/components/Events/AbstractEventRenderer.ts
+++ b/src/components/Events/AbstractEventRenderer.ts
@@ -1,4 +1,5 @@
 import { TimelineEvent } from "../../types/events";
+import { ViewConfiguration } from "../../types";
 
 export type Hitbox = {
   top: number;
@@ -16,8 +17,8 @@ export abstract class AbstractEventRenderer {
     x1: number,
     y: number,
     h: number,
+    viewConfiguration: ViewConfiguration,
     timeToPosition?: (n: number) => number,
-    color?: string,
   ): void;
 
   protected hitboxResult: Hitbox = {

--- a/src/components/Events/Events.ts
+++ b/src/components/Events/Events.ts
@@ -51,7 +51,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
   public getEventsAt(rect: DOMRect): Event[] {
     const {
       events: { hitboxPadding },
-    } = this.api.getVisualConfiguration();
+    } = this.api.getViewConfiguration();
     const rulerHeight = this.api.getRulerHeight();
     const topOffset = -rulerHeight + this.api.canvasScrollTop;
     const events = this.index.search({
@@ -141,7 +141,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
   }
 
   public render() {
-    const viewConfiguration = this.api.getVisualConfiguration();
+    const viewConfiguration = this.api.getViewConfiguration();
     const { start, end } = this.api.getInterval();
     const axesComponent = this.api.getComponent<Axes>(ComponentType.Axes);
 
@@ -316,7 +316,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
    */
   protected rebuildIndex(): void {
     const { end } = this.api.getInterval();
-    const { axes } = this.api.getVisualConfiguration();
+    const { axes } = this.api.getViewConfiguration();
 
     const axesComponent = this.api.getComponent<Axes>(ComponentType.Axes);
     const axesById = axesComponent.getAxesById();

--- a/src/components/Events/Events.ts
+++ b/src/components/Events/Events.ts
@@ -7,6 +7,7 @@ import { CanvasApi } from "../../CanvasApi";
 import { ComponentType } from "../../enums";
 import { BaseComponentInterface } from "../../types/component";
 import { TimelineEvent } from "../../types/events";
+import { ViewConfiguration } from "../../types";
 
 const MAX_INDEX_TREE_WIDTH = 16;
 
@@ -140,7 +141,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
   }
 
   public render() {
-    const { events } = this.api.getVisualConfiguration();
+    const viewConfiguration = this.api.getVisualConfiguration();
     const { start, end } = this.api.getInterval();
     const axesComponent = this.api.getComponent<Axes>(ComponentType.Axes);
 
@@ -155,7 +156,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
 
     ctx.translate(0, this.api.getRulerHeight());
 
-    ctx.font = events.font;
+    ctx.font = viewConfiguration.events.font;
     ctx.lineWidth = 2;
 
     for (let i = 0, len = this._events.length; i < len; i += 1) {
@@ -178,6 +179,7 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
           x1,
           y,
           axis.height,
+          viewConfiguration,
           timeToPosition,
         );
       }
@@ -220,8 +222,8 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
    * @param x1 - End X coordinate
    * @param y - Y coordinate
    * @param h - Height of the event
+   * @param viewConfiguration - Timeline view configuration
    * @param timeToPosition - Optional function to convert time to position
-   * @param color - Optional color override
    */
   protected runRenderer(
     ctx: CanvasRenderingContext2D,
@@ -231,8 +233,8 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
     x1: number,
     y: number,
     h: number,
+    viewConfiguration: ViewConfiguration,
     timeToPosition?: (n: number) => number,
-    color?: string,
   ) {
     if (!event.renderer) {
       event.renderer = new DefaultEventRenderer();
@@ -246,8 +248,8 @@ export class Events<Event extends TimelineEvent = TimelineEvent>
       x1,
       y,
       h,
+      viewConfiguration,
       timeToPosition,
-      color,
     );
   }
 

--- a/src/components/Grid.ts
+++ b/src/components/Grid.ts
@@ -14,7 +14,7 @@ export class Grid implements BaseComponentInterface {
 
   constructor(api: CanvasApi) {
     this.api = api;
-    this.levels = getGridLevels(this.api.getVisualConfiguration().grid);
+    this.levels = getGridLevels(this.api.getViewConfiguration().grid);
   }
 
   /**
@@ -55,7 +55,7 @@ export class Grid implements BaseComponentInterface {
       // Check if the marks fit within the visible area
       if (
         this.calculateMarksWidth(level, domainSize) >
-        canvasWidth + this.api.getVisualConfiguration().grid.widthBuffer
+        canvasWidth + this.api.getViewConfiguration().grid.widthBuffer
       ) {
         continue;
       }
@@ -76,7 +76,7 @@ export class Grid implements BaseComponentInterface {
 
     while (Number(time) < domainSize) {
       const x = convertDomain(Number(time), 0, domainSize, 0, totalWidth);
-      totalWidth += x > 0 ? this.api.getVisualConfiguration().grid.spacing : 0;
+      totalWidth += x > 0 ? this.api.getViewConfiguration().grid.spacing : 0;
       time = level.step(time);
     }
 
@@ -93,7 +93,7 @@ export class Grid implements BaseComponentInterface {
     height: number,
     level: TGridLevel,
   ) {
-    const { grid } = this.api.getVisualConfiguration();
+    const { grid } = this.api.getViewConfiguration();
     const { start, end } = this.api.getInterval();
     const { ctx } = this.api;
     ctx.lineWidth = grid.lineWidth;

--- a/src/components/Markers.ts
+++ b/src/components/Markers.ts
@@ -36,7 +36,7 @@ export class Markers implements BaseComponentInterface {
     // Reset label positions for new render pass
     this.lastRenderedLabelPosition = { top: Infinity, bottom: Infinity };
 
-    const { markers } = this.api.getVisualConfiguration();
+    const { markers } = this.api.getViewConfiguration();
     const { start, end } = this.api.getInterval();
 
     // Render markers in reverse order for proper label placement
@@ -65,7 +65,7 @@ export class Markers implements BaseComponentInterface {
    * @param marker - Marker data to render
    */
   protected renderMarker(marker: TimelineMarker) {
-    const { markers } = this.api.getVisualConfiguration();
+    const { markers } = this.api.getViewConfiguration();
     const ctx = this.api.ctx;
     const markerPosition = this.api.timeToPosition(marker.time);
 
@@ -123,7 +123,7 @@ export class Markers implements BaseComponentInterface {
     }: { label: string; backgroundColor: string; textColor?: string },
     position: "top" | "bottom",
   ) {
-    const { markers } = this.api.getVisualConfiguration();
+    const { markers } = this.api.getViewConfiguration();
     const ctx = this.api.ctx;
     const labelWidth = this.getLabelWidth(label);
 
@@ -161,7 +161,7 @@ export class Markers implements BaseComponentInterface {
       return this.textWidthCache.get(text);
     }
 
-    const { markers } = this.api.getVisualConfiguration();
+    const { markers } = this.api.getViewConfiguration();
     const width =
       this.api.ctx.measureText(text).width + markers.labelPadding * 2;
     this.textWidthCache.set(text, width);

--- a/src/components/Ruler.ts
+++ b/src/components/Ruler.ts
@@ -16,14 +16,14 @@ export class Ruler implements BaseComponentInterface {
 
   constructor(api: CanvasApi) {
     this.api = api;
-    this.labelLevels = getLabelLevels(this.api.getVisualConfiguration().ruler);
+    this.labelLevels = getLabelLevels(this.api.getViewConfiguration().ruler);
   }
 
   /**
    * Renders the ruler component including background, labels and grid lines
    */
   public render() {
-    const { ruler } = this.api.getVisualConfiguration();
+    const { ruler } = this.api.getViewConfiguration();
     const { ctx, width } = this.api;
     this.api.useStaticTransform();
 
@@ -46,7 +46,7 @@ export class Ruler implements BaseComponentInterface {
    * Uses ruler's border color from visual configuration
    */
   private renderBottomLine() {
-    const { ruler } = this.api.getVisualConfiguration();
+    const { ruler } = this.api.getViewConfiguration();
     const { ctx, width } = this.api;
 
     ctx.strokeStyle = ruler.color.borderColor;
@@ -62,7 +62,7 @@ export class Ruler implements BaseComponentInterface {
    */
   private renderLevels() {
     const { start, end } = this.api.getInterval();
-    const { ruler } = this.api.getVisualConfiguration();
+    const { ruler } = this.api.getViewConfiguration();
     if (!ruler) return;
 
     const domain = end - start;
@@ -115,7 +115,7 @@ export class Ruler implements BaseComponentInterface {
     domain: number,
     width: number,
   ): number {
-    const { ruler } = this.api.getVisualConfiguration();
+    const { ruler } = this.api.getViewConfiguration();
     let marksWidth = 0;
 
     for (let t = dayjs(0); Number(t) < domain; t = level.step(t)) {
@@ -137,7 +137,7 @@ export class Ruler implements BaseComponentInterface {
     y: number,
     color: string,
   ) {
-    const { ruler } = this.api.getVisualConfiguration();
+    const { ruler } = this.api.getViewConfiguration();
     const { start, end } = this.api.getInterval();
     const { ctx, width } = this.api;
 


### PR DESCRIPTION
## Summary by Sourcery

Standardize configuration access by renaming getVisualConfiguration to getViewConfiguration and propagate the updated viewConfiguration object through all rendering components.

Enhancements:
- Rename CanvasApi.getVisualConfiguration to getViewConfiguration
- Update all components (Events, Ruler, Grid, Markers, Axes) to use getViewConfiguration instead of getVisualConfiguration
- Import and use the ViewConfiguration type where needed
- Extend event renderer interfaces to accept the viewConfiguration parameter and pass it through render calls