### PR TITLE
fix(Config): removed unused parameter

### DIFF
--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -43,7 +43,6 @@ export const defaultViewConfig: ViewConfigurationDefault = {
   events: {
     font: DEFAULT_FONT,
     hitboxPadding: 2,
-    maxIndexTreeWidth: 16,
   },
   markers: {
     labelPadding: 3,

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -43,7 +43,6 @@ export type AxesViewOptions = {
 export type EnetsViewOptions = {
   hitboxPadding?: number;
   font?: string;
-  maxIndexTreeWidth?: number;
 };
 
 export type MarkerViewOptions = {


### PR DESCRIPTION
## Summary by Sourcery

Remove the unused maxIndexTreeWidth parameter from default configuration and type definitions

Chores:
- Remove maxIndexTreeWidth from defaultViewConfig.events
- Remove maxIndexTreeWidth from EnetsViewOptions type