### PR TITLE
feat(Settings): add selected events in config

### DIFF
--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -39,6 +39,7 @@ export class Timeline {
    *     end: Date.now() + 3600000,
    *     axes: [],
    *     events: []
+   *     selectedEventIds: []
    *   }
    * });
    */
@@ -72,6 +73,7 @@ export class Timeline {
     this.api.setAxes(this.settings.axes);
     this.api.setEvents(this.settings.events);
     this.api.setMarkers(this.settings.markers || []);
+    this.api.setSelectedEvents(this.settings.selectedEventIds || []);
 
     this.controller = new TimelineController(this.api);
     this.state = TimelineState.READY;

--- a/src/stories/Events.stories.tsx
+++ b/src/stories/Events.stories.tsx
@@ -67,6 +67,15 @@ const meta = {
         },
       },
     },
+    "settings.selectedEventIds": {
+      control: {
+        type: "object",
+      },
+      description: "Selected event ids",
+      table: {
+        category: "settings",
+      },
+    },
     "viewConfiguration.hideRuler": {
       control: {
         type: "boolean",
@@ -170,6 +179,7 @@ export const Basic: Story = {
     "settings.end": baseTimelineConfig.settings.end,
     "settings.axes": baseTimelineConfig.settings.axes,
     "settings.events": baseTimelineConfig.settings.events,
+    "settings.selectedEventIds": baseTimelineConfig.settings.selectedEventIds,
     ...defaultViewConfigArgs,
   },
   parameters: {
@@ -188,6 +198,7 @@ export const EndlessTimelines: Story = {
     "settings.end": endlessTimelineConfig.settings.end,
     "settings.axes": endlessTimelineConfig.settings.axes,
     "settings.events": endlessTimelineConfig.settings.events,
+    "settings.selectedEventIds": baseTimelineConfig.settings.selectedEventIds,
     ...defaultViewConfigArgs,
   },
   parameters: {
@@ -206,6 +217,7 @@ export const CustomRenderer: Story = {
     "settings.end": customRendererConfig.settings.end,
     "settings.axes": customRendererConfig.settings.axes,
     "settings.events": customRendererConfig.settings.events,
+    "settings.selectedEventIds": baseTimelineConfig.settings.selectedEventIds,
     ...defaultViewConfigArgs,
   },
   parameters: {

--- a/src/stories/configs/common.ts
+++ b/src/stories/configs/common.ts
@@ -2,7 +2,7 @@ import { TimeLineConfig } from "../../types";
 
 export const commonConfig: Pick<
   TimeLineConfig["settings"],
-  "start" | "end" | "axes"
+  "start" | "end" | "axes" | "selectedEventIds"
 > = {
   start: 1739537126347,
   end: 1739537186347,
@@ -14,4 +14,5 @@ export const commonConfig: Pick<
       height: 20,
     },
   ],
+  selectedEventIds: [],
 };

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -71,6 +71,7 @@ export type TimelineSettings = {
   axes: TimelineAxis[];
   events: TimelineEvent[];
   markers?: TimelineMarker[];
+  selectedEventIds?: string[];
 };
 
 export type TimeLineConfig = {


### PR DESCRIPTION
## Summary by Sourcery

Add selectedEventIds as a configurable setting and wire it through the common config, Storybook controls, and Timeline API to enable pre-selecting events.

New Features:
- Add selectedEventIds setting to TimeLineConfig and TimelineSettings to allow specifying pre-selected events

Enhancements:
- Add selectedEventIds field to common config and storybook controls and integrate it into all story variants