### PR TITLE
fix: reset canvas transform before clearing to prevent rendering artifacts

### DIFF
--- a/src/CanvasApi.ts
+++ b/src/CanvasApi.ts
@@ -202,6 +202,7 @@ export class CanvasApi<
   }
 
   public clear(): void {
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
   }
 


### PR DESCRIPTION
`CanvasApi.clear()` used `clearRect` without resetting the canvas transform to identity first. When external code (e.g. `Events.setSelectedEvents()`) called `render()` directly outside of the `rerender()` cycle, it left a dirty scroll transform on the canvas context. On the next `rerender()`, `clearRect` operated in the transformed coordinate space — and with a large `canvasScrollTop`, the clear area shifted entirely above the visible canvas, resulting in nothing being cleared. Subsequent component renders drew on top of stale content, producing visual ghosting artifacts.

The fix resets the transform to identity `(1, 0, 0, 1, 0, 0)` before `clearRect`, ensuring the full physical canvas is always cleared regardless of any residual transform state.